### PR TITLE
修复linux下链接异常

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(${PROJECT_NAME} ${CRYPTO_LIBS})
 target_link_libraries(${PROJECT_NAME} ${CLIENT_LIBS})
 if (${TARGET_OS} STREQUAL "LINUX")
 target_link_libraries(${PROJECT_NAME} pthread)	
+target_link_libraries(${PROJECT_NAME} lm)
 endif()
 
 target_compile_options(${PROJECT_NAME} 


### PR DESCRIPTION
linux链接会有如下问题
/usr/bin/ld: /usr/local/ali-openssl/lib/libcrypto.a(dso_dlfcn.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
//usr/lib64/libdl.so.2: error adding symbols: DSO missing from command line

