### PR TITLE
enable/disable treat all warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(BUILD_SAMPLE "Build sample" ON)
 option(BUILD_TESTS "Build unit and perfermence tests" OFF)
 option(ENABLE_COVERAGE "Flag to enable/disable building code with -fprofile-arcs and -ftest-coverage. Gcc only" OFF)
 option(ENABLE_RTTI "Flag to enable/disable building code with RTTI information" ON)
+option(ENABLE_TREAT_WARNING_AS_ERROR "Flag to enabled/disable treating all warnings to errors" ON)
 
 
 #Platform
@@ -118,7 +119,10 @@ else()
 	list(APPEND SDK_COMPILER_FLAGS "-fno-rtti")
 	endif()
 	
-	list(APPEND SDK_COMPILER_FLAGS "-Wall" "-Werror" "-pedantic" "-Wextra")
+	list(APPEND SDK_COMPILER_FLAGS "-Wall" "-pedantic" "-Wextra")
+        if (ENABLE_TREAT_WARNING_AS_ERROR)
+	list(APPEND SDK_COMPILER_FLAGS "-Werror")
+        endif()
 	
 	if (ENABLE_COVERAGE)
 	SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")


### PR DESCRIPTION
如果打开-Werror，则linux编译会报错。
增加一个开关

![截屏2023-09-22 16 54 35](https://github.com/aliyun/aliyun-oss-cpp-sdk/assets/5937168/4e675eb7-794f-4d3e-90fc-22f8940e281d)
